### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ By default it expects your block files to be located directly in the `src_folder
 ```
 .
 └── blocks
-    ├── out
+    ├── dest
     │   └── index.js
     └── src
         ├── Banner.js


### PR DESCRIPTION
Typo in the instructions, as we expect the files in the dest dir, not the out.